### PR TITLE
Added setting to exclude renderings below path(s)

### DIFF
--- a/NitroNet.Sitecore/App_Config/Include/NitroNet/NitroNet.Sitecore.Settings.config
+++ b/NitroNet.Sitecore/App_Config/Include/NitroNet/NitroNet.Sitecore.Settings.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <sitecore>
+    <settings>
+      <!--  Pipe separated list containing paths inside renderings folder. All renderings below path are excluded from nitronet. -->
+      <setting name="NitroNet.Sitecore.General.RenderingExclusions" value=""/>
+    </settings>
+    </sitecore>
+</configuration>

--- a/NitroNet.Sitecore/NitroNet.Sitecore.csproj
+++ b/NitroNet.Sitecore/NitroNet.Sitecore.csproj
@@ -214,6 +214,7 @@
     <None Include="app.config" />
     <Content Include="App_Config\Include\NitroNet\EventHandlingInitializer.config" />
     <Content Include="App_Config\Include\NitroNet\RegisterViewEngine.config" />
+    <None Include="App_Config\Include\NitroNet\NitroNet.Sitecore.Settings.config" />
     <None Include="NitroNet.Sitecore.nuspec">
       <SubType>Designer</SubType>
     </None>

--- a/docs/releases/2.0.0.md
+++ b/docs/releases/2.0.0.md
@@ -11,6 +11,7 @@
 - The Sitecore libraries (DLLs) were removed from the repository and the Sitecore PackageReference approach was implemented
 	- Sitecore Support fixes relevant for Sitecore 8.1/8.2 were directly integrated into the code
 - The view engine now automatically gets registered with a config file. This saves an additional step in the installation process. - Issue [20](https://github.com/namics/NitroNetSitecore/issues/20)
+- Added setting `NitroNet.Sitecore.General.RenderingExclusions` for exclusion of rendering-items below pipe separated paths
 
 ### Fixed Issues
 - Rendering cache isn't properly updated on CD servers after publishing


### PR DESCRIPTION
Added new setting which holds a pipe separated list of paths. All renderings below the path(s) are ignored by the rendering repository. Can avoid the duplicate key exception caused by multiple renderings with the same name.